### PR TITLE
List files interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <github.url>scm:git:git@github.com:jmchilton/dockstore-galaxy-interface.git</github.url>
-        <dockstore.version>1.8.0-alpha.3-SNAPSHOT</dockstore.version>
+        <dockstore.version>1.8.0-alpha.3-GALAXYEXP</dockstore.version>
         <slf4j.version>1.7.26</slf4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <github.url>scm:git:git@github.com:jmchilton/dockstore-galaxy-interface.git</github.url>
-        <dockstore.version>1.7.0-alpha.6</dockstore.version>
+        <dockstore.version>1.8.0-alpha.3-SNAPSHOT</dockstore.version>
         <slf4j.version>1.7.26</slf4j.version>
     </properties>
 
@@ -174,6 +174,19 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>27.0.1-jre</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.kohsuke/github-api -->
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.92</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/org/galaxyproject/dockstore_galaxy_interface/language/PrepareSerializedDirectoryListings.java
+++ b/src/test/java/org/galaxyproject/dockstore_galaxy_interface/language/PrepareSerializedDirectoryListings.java
@@ -1,0 +1,51 @@
+package org.galaxyproject.dockstore_galaxy_interface.language;
+
+import static org.galaxyproject.dockstore_galaxy_interface.language.GalaxyWorkflowLanguagePluginTest.CURRENT_BRANCH;
+import static org.galaxyproject.dockstore_galaxy_interface.language.GalaxyWorkflowLanguagePluginTest.REPO_ID_1;
+import static org.galaxyproject.dockstore_galaxy_interface.language.GalaxyWorkflowLanguagePluginTest.REPO_ID_2;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+
+public class PrepareSerializedDirectoryListings {
+
+  /**
+   * GitHub calls in this repo are not authorized and thus are subject to rate limit. This method
+   * serializes directory listings. Run this to re-generate directory listings for testing.
+   *
+   * @param args none
+   */
+  public static void main(String[] args) throws IOException {
+
+    List<String> content1 = getDirectoryListing(REPO_ID_1);
+    List<String> content2 = getDirectoryListing(REPO_ID_2);
+
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    System.out.println(gson.toJson(content1));
+    System.out.println(gson.toJson(content2));
+
+    FileUtils.writeStringToFile(
+        new File("src/test/resources/" + REPO_ID_1 + "/listing.json"), gson.toJson(content1));
+    FileUtils.writeStringToFile(
+        new File("src/test/resources/" + REPO_ID_2 + "/listing.json"), gson.toJson(content2));
+  }
+
+  private static List<String> getDirectoryListing(String id) throws IOException {
+    final GitHub github = new GitHubBuilder().build();
+    GHRepository repo1 = github.getRepository(id);
+    // TODO: parameterize path for nested directories
+    List<GHContent> directoryContent1 = repo1.getDirectoryContent("/", CURRENT_BRANCH);
+    return directoryContent1.stream()
+        .map(content -> "/" + content.getName())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/test/resources/jmchilton/galaxy-workflow-dockstore-example-1/listing.json
+++ b/src/test/resources/jmchilton/galaxy-workflow-dockstore-example-1/listing.json
@@ -1,0 +1,5 @@
+[
+  "/Dockstore.gxwf-test.yml",
+  "/Dockstore.gxwf.yml",
+  "/test-data"
+]

--- a/src/test/resources/jmchilton/galaxy-workflow-dockstore-example-2/listing.json
+++ b/src/test/resources/jmchilton/galaxy-workflow-dockstore-example-2/listing.json
@@ -1,0 +1,7 @@
+[
+  "/Dockstore-job-url.yml",
+  "/Dockstore-job.yml",
+  "/Dockstore-test.yml",
+  "/Dockstore.ga",
+  "/hello.txt"
+]


### PR DESCRIPTION
* some work to get something released on artifactory on both the plugin and dockstore side
* adding a "list files" method, it isn't obvious but github api supports conditional requests to conserve rate limit, means that listing files and looking through them is much more efficient than guessing their names, also cleans up a part of plugin
https://developer.github.com/v3/#rate-limiting
* however, didn't want to check in a GitHub api key in this repo too to use the API, so created a "prep" method to serialize directory listings