### PR TITLE
Feature/enhance dag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,12 @@
             <version>2.10.1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <plugin.id>${project.artifactId}</plugin.id>
         <plugin.class>org.galaxyproject.dockstore_galaxy_interface.language.GalaxyWorkflowPlugin</plugin.class>
         <plugin.version>${project.version}</plugin.version>
+        <jackson.version>2.10.1</jackson.version>
         <plugin.provider>jmchilton</plugin.provider>
         <plugin.dependencies />
     </properties>
@@ -223,13 +224,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.1</version>
+            <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.1</version>
+            <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,12 @@
             <version>2.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.10.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/src/main/java/org/galaxyproject/dockstore_galaxy_interface/language/GalaxyWorkflowPlugin.java
+++ b/src/main/java/org/galaxyproject/dockstore_galaxy_interface/language/GalaxyWorkflowPlugin.java
@@ -32,6 +32,9 @@ import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.error.YAMLException;
 
+import static org.galaxyproject.gxformat2.Cytoscape.END_ID;
+import static org.galaxyproject.gxformat2.Cytoscape.START_ID;
+
 /** @author jmchilton */
 public class GalaxyWorkflowPlugin extends Plugin {
   public static final Logger LOG = LoggerFactory.getLogger(GalaxyWorkflowPlugin.class);
@@ -74,7 +77,7 @@ public class GalaxyWorkflowPlugin extends Plugin {
               node -> {
                 Map data = (Map) node.get("data");
                 String id = (String) data.get("id");
-                return "UniqueBeginKey".equals(id) || "UniqueEndKey".equals(id);
+                return START_ID.equals(id) || END_ID.equals(id);
               });
       return nodes.stream().map(node -> {
         final RowData rowData = new RowData();

--- a/src/main/java/org/galaxyproject/dockstore_galaxy_interface/language/GalaxyWorkflowPlugin.java
+++ b/src/main/java/org/galaxyproject/dockstore_galaxy_interface/language/GalaxyWorkflowPlugin.java
@@ -70,6 +70,12 @@ public class GalaxyWorkflowPlugin extends Plugin {
       final Map<String, Object> workflow = loadWorkflow(contents);
       final Map<String, Object> elements = Cytoscape.getElements(workflow);
       final List<Map> nodes = (List<Map>)elements.getOrDefault("nodes", Lists.newArrayList());
+      nodes.removeIf(
+              node -> {
+                Map data = (Map) node.get("data");
+                String id = (String) data.get("id");
+                return "UniqueBeginKey".equals(id) || "UniqueEndKey".equals(id);
+              });
       return nodes.stream().map(node -> {
         final RowData rowData = new RowData();
         final Map<String, Object> nodeData = (Map<String, Object>)node.get("data");

--- a/src/main/java/org/galaxyproject/dockstore_galaxy_interface/language/GalaxyWorkflowPlugin.java
+++ b/src/main/java/org/galaxyproject/dockstore_galaxy_interface/language/GalaxyWorkflowPlugin.java
@@ -73,12 +73,7 @@ public class GalaxyWorkflowPlugin extends Plugin {
       final Map<String, Object> workflow = loadWorkflow(contents);
       final Map<String, Object> elements = Cytoscape.getElements(workflow);
       final List<Map> nodes = (List<Map>)elements.getOrDefault("nodes", Lists.newArrayList());
-      nodes.removeIf(
-              node -> {
-                Map data = (Map) node.get("data");
-                String id = (String) data.get("id");
-                return START_ID.equals(id) || END_ID.equals(id);
-              });
+      removeStartAndEndNodes(nodes);
       return nodes.stream().map(node -> {
         final RowData rowData = new RowData();
         final Map<String, Object> nodeData = (Map<String, Object>)node.get("data");
@@ -95,6 +90,15 @@ public class GalaxyWorkflowPlugin extends Plugin {
         rowData.toolid = (String)nodeData.getOrDefault("id", "");
         return rowData;
       }).collect(Collectors.toList());
+    }
+
+    // Remove start and end nodes that were added for DAG
+    private void removeStartAndEndNodes(List<Map> nodes) {
+        nodes.removeIf(node -> {
+          Map data = (Map)node.get("data");
+          String id = (String)data.get("id");
+          return START_ID.equals(id) || END_ID.equals(id);
+        });
     }
 
     @Override

--- a/src/main/java/org/galaxyproject/gxformat2/Cytoscape.java
+++ b/src/main/java/org/galaxyproject/gxformat2/Cytoscape.java
@@ -83,7 +83,7 @@ public class Cytoscape {
       nodeData.put("tool_id", step.get("tool_id"));
       nodeData.put("doc", normalizedStep.doc);
       nodeData.put("repo_link", repoLink);
-      nodeData.put("step_type", stepType);
+      nodeData.put("type", stepType);
       final Map<String, Object> nodeElement = new HashMap<String, Object>();
       nodeElement.put("group", "nodes");
       nodeElement.put("data", nodeData);

--- a/src/main/java/org/galaxyproject/gxformat2/Cytoscape.java
+++ b/src/main/java/org/galaxyproject/gxformat2/Cytoscape.java
@@ -14,8 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class Cytoscape {
   public static final ObjectMapper objectMapper = new ObjectMapper();
   public static final String MAIN_TS_PREFIX = "toolshed.g2.bx.psu.edu/repos/";
-  private static final String START_ID = "UniqueBeginKey";
-  private static final String END_ID = "UniqueEndKey";
+  public static final String START_ID = "UniqueBeginKey";
+  public static final String END_ID = "UniqueEndKey";
 
   public static Map<String, Object> getElements(final String path) throws Exception {
     final Map<String, Object> object = (Map<String, Object>) IoUtils.readYamlFromPath(path);

--- a/src/main/java/org/galaxyproject/gxformat2/CytoscapeDAG.java
+++ b/src/main/java/org/galaxyproject/gxformat2/CytoscapeDAG.java
@@ -1,8 +1,7 @@
 package org.galaxyproject.gxformat2;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 /**
  * @author gluu

--- a/src/main/java/org/galaxyproject/gxformat2/CytoscapeDAG.java
+++ b/src/main/java/org/galaxyproject/gxformat2/CytoscapeDAG.java
@@ -1,0 +1,163 @@
+package org.galaxyproject.gxformat2;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author gluu
+ * @since 2020-03-03
+ */
+public class CytoscapeDAG {
+  @JsonProperty("nodes")
+  private List<Node> nodes = null;
+
+  @JsonProperty("edges")
+  private List<Edge> edges = null;
+
+  @JsonProperty("nodes")
+  public List<Node> getNodes() {
+    return nodes;
+  }
+
+  @JsonProperty("nodes")
+  public void setNodes(List<Node> nodes) {
+    this.nodes = nodes;
+  }
+
+  @JsonProperty("edges")
+  public List<Edge> getEdges() {
+    return edges;
+  }
+
+  @JsonProperty("edges")
+  public void setEdges(List<Edge> edges) {
+    this.edges = edges;
+  }
+
+  public static class Node {
+    @JsonProperty("data")
+    private Node.NodeData data;
+
+    @JsonProperty("data")
+    public NodeData getData() {
+      return data;
+    }
+
+    @JsonProperty("data")
+    public void setData(Node.NodeData data) {
+      this.data = data;
+    }
+
+    public static class NodeData {
+
+      @JsonProperty("name")
+      private String name;
+
+      @JsonProperty("run")
+      private String run;
+
+      @JsonProperty("id")
+      private String id;
+
+      @JsonProperty("docker")
+      private String docker;
+
+      @JsonProperty("name")
+      public String getName() {
+        return name;
+      }
+
+      @JsonProperty("name")
+      public void setName(String name) {
+        this.name = name;
+      }
+
+      @JsonProperty("run")
+      public String getRun() {
+        return run;
+      }
+
+      @JsonProperty("run")
+      public void setRun(String run) {
+        this.run = run;
+      }
+
+      @JsonProperty("id")
+      public String getId() {
+        return id;
+      }
+
+      @JsonProperty("id")
+      public void setId(String id) {
+        this.id = id;
+      }
+
+      @JsonProperty("docker")
+      public String getDocker() {
+        return docker;
+      }
+
+      @JsonProperty("docker")
+      public void setDocker(String docker) {
+        this.docker = docker;
+      }
+    }
+  }
+
+  public static class Edge {
+    @JsonProperty("data")
+    private EdgeData data;
+
+    @JsonProperty("data")
+    public EdgeData getData() {
+      return data;
+    }
+
+    @JsonProperty("data")
+    public void setData(EdgeData data) {
+      this.data = data;
+    }
+
+    public static class EdgeData {
+      @JsonProperty("id")
+      private String id;
+
+      @JsonProperty("source")
+      private String source;
+
+      @JsonProperty("target")
+      private String target;
+
+      @JsonProperty("id")
+      public String getId() {
+        return id;
+      }
+
+      @JsonProperty("id")
+      public void setId(String id) {
+        this.id = id;
+      }
+
+      @JsonProperty("source")
+      public String getSource() {
+        return source;
+      }
+
+      @JsonProperty("source")
+      public void setSource(String source) {
+        this.source = source;
+      }
+
+      @JsonProperty("target")
+      public String getTarget() {
+        return target;
+      }
+
+      @JsonProperty("target")
+      public void setTarget(String target) {
+        this.target = target;
+      }
+    }
+  }
+}

--- a/src/test/java/org/galaxyproject/gxformat2/CytoscapeTest.java
+++ b/src/test/java/org/galaxyproject/gxformat2/CytoscapeTest.java
@@ -12,89 +12,70 @@ import com.google.gson.Gson;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.galaxyproject.gxformat2.Cytoscape.END_ID;
+import static org.galaxyproject.gxformat2.Cytoscape.START_ID;
+
 public class CytoscapeTest {
-  // Test with steps that don't have labels
+  public static final Gson gson = new Gson();
+
+  /**
+   * Test with steps that don't have labels
+   * @throws Exception Cytoscape exception
+   */
   @Test
-  public void testGetElements() throws Exception {
-    Gson gson = new Gson();
+  public void testGetElementsWithoutLabels() throws Exception {
     File testFile = new File("src/test/resources/transcriptomics-denovo-workflow.ga");
     Map<String, Object> elements = Cytoscape.getElements(testFile.getAbsolutePath());
     String json = gson.toJson(elements);
-    CytoscapeDAG cytoscapeDAG = gson.fromJson(json, CytoscapeDAG.class);
-    Set<String> collect =
-        cytoscapeDAG.getNodes().stream()
-            .map(node -> node.getData().getId())
-            .collect(Collectors.toSet());
-    Assert.assertEquals("Ids are distinct", collect.size(), cytoscapeDAG.getNodes().size());
-    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueBeginKey")));
-    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueEndKey")));
-    cytoscapeDAG.getEdges().stream()
-        .map(CytoscapeDAG.Edge::getData)
-        .forEach(
-            data ->
-                Assert.assertNotEquals(
-                    "Source and target should be different", data.getSource(), data.getTarget()));
     Assert.assertFalse(elements.isEmpty());
-    List<String> startingSteps =
-        cytoscapeDAG.getEdges().stream()
-            .filter(edge -> edge.getData().getSource().equals("UniqueBeginKey"))
-            .map(edge -> edge.getData().getTarget())
-            .collect(Collectors.toList());
-    List<String> endingSteps =
-        cytoscapeDAG.getEdges().stream()
-            .filter(edge -> edge.getData().getTarget().equals("UniqueEndKey"))
-            .map(edge -> edge.getData().getSource())
-            .collect(Collectors.toList());
     List<String> knownStartingSteps = Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8");
     List<String> knownEndingSteps =
         Arrays.asList(
             "46", "45", "36", "35", "33", "32", "30", "29", "27", "26", "19", "18", "16", "15",
             "13", "12", "10", "9");
-    Collections.sort(knownStartingSteps);
-    Collections.sort(knownEndingSteps);
-    Collections.sort(startingSteps);
-    Collections.sort(endingSteps);
-    Assert.assertEquals(knownStartingSteps, startingSteps);
-    Assert.assertEquals(knownEndingSteps, endingSteps);
+    generalTest(knownStartingSteps, knownEndingSteps, json);
   }
 
   /**
    * Test with steps that have labels
-   * @throws Exception
+   * @throws Exception  Cytoscape exception
    */
   @Test
-  public void testGetElements2() throws Exception {
-    Gson gson = new Gson();
+  public void testGetElementsWithLabels() throws Exception {
     File testFile = new File("src/test/resources/anotherFile.ga");
     Map<String, Object> elements = Cytoscape.getElements(testFile.getAbsolutePath());
     String json = gson.toJson(elements);
+    List<String> knownStartingSteps = new java.util.ArrayList<>(Collections.singletonList("0"));
+    List<String> knownEndingSteps = new java.util.ArrayList<>(Collections.singletonList("1"));
+    generalTest(knownStartingSteps, knownEndingSteps, json);
+
+  }
+
+  public void generalTest(List<String> knownStartingSteps, List<String> knownEndingSteps, String json) {
     CytoscapeDAG cytoscapeDAG = gson.fromJson(json, CytoscapeDAG.class);
     Set<String> collect =
-        cytoscapeDAG.getNodes().stream()
-            .map(node -> node.getData().getId())
-            .collect(Collectors.toSet());
+            cytoscapeDAG.getNodes().stream()
+                    .map(node -> node.getData().getId())
+                    .collect(Collectors.toSet());
     Assert.assertEquals("Ids are distinct", collect.size(), cytoscapeDAG.getNodes().size());
-    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueBeginKey")));
-    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueEndKey")));
+    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals(START_ID)));
+    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals(END_ID)));
     cytoscapeDAG.getEdges().stream()
-        .map(CytoscapeDAG.Edge::getData)
-        .forEach(
-            data ->
-                Assert.assertNotEquals(
-                    "Source and target should be different", data.getSource(), data.getTarget()));
-    Assert.assertFalse(elements.isEmpty());
+            .map(CytoscapeDAG.Edge::getData)
+            .forEach(
+                    data ->
+                            Assert.assertNotEquals(
+                                    "Source and target should be different", data.getSource(), data.getTarget()));
     List<String> startingSteps =
-        cytoscapeDAG.getEdges().stream()
-            .filter(edge -> edge.getData().getSource().equals("UniqueBeginKey"))
-            .map(edge -> edge.getData().getTarget())
-            .collect(Collectors.toList());
+            cytoscapeDAG.getEdges().stream()
+                    .filter(edge -> edge.getData().getSource().equals(START_ID))
+                    .map(edge -> edge.getData().getTarget())
+                    .collect(Collectors.toList());
     List<String> endingSteps =
-        cytoscapeDAG.getEdges().stream()
-            .filter(edge -> edge.getData().getTarget().equals("UniqueEndKey"))
-            .map(edge -> edge.getData().getSource())
-            .collect(Collectors.toList());
-    List<String> knownStartingSteps = Collections.singletonList("0");
-    List<String> knownEndingSteps = Collections.singletonList("1");
+            cytoscapeDAG.getEdges().stream()
+                    .filter(edge -> edge.getData().getTarget().equals(END_ID))
+                    .map(edge -> edge.getData().getSource())
+                    .collect(Collectors.toList());
     Collections.sort(knownStartingSteps);
     Collections.sort(knownEndingSteps);
     Collections.sort(startingSteps);

--- a/src/test/java/org/galaxyproject/gxformat2/CytoscapeTest.java
+++ b/src/test/java/org/galaxyproject/gxformat2/CytoscapeTest.java
@@ -13,31 +13,93 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class CytoscapeTest {
-    @Test
-    public void testGetElements() throws Exception {
-        Gson gson = new Gson();
-        File testFile = new File("src/test/resources/transcriptomics-denovo-workflow.ga");
-        Map<String, Object> elements = Cytoscape.getElements(testFile.getAbsolutePath());
-        String json = gson.toJson(elements);
-        CytoscapeDAG cytoscapeDAG = gson.fromJson(json, CytoscapeDAG.class);
-        Set<String> collect = cytoscapeDAG.getNodes().stream().map(node -> node.getData().getId()).collect(Collectors.toSet());
-        Assert.assertEquals("Ids are distinct", collect.size(), cytoscapeDAG.getNodes().size());
-        Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueBeginKey")));
-        Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueEndKey")));
-        cytoscapeDAG.getEdges().stream().map(CytoscapeDAG.Edge::getData)
-                .forEach(data -> Assert.assertNotEquals("Source and target should be different", data.getSource(), data.getTarget()));
-        Assert.assertFalse(elements.isEmpty());
-      List<String> startingSteps = cytoscapeDAG.getEdges().stream().filter(edge -> edge.getData().getSource().equals("UniqueBeginKey")).map(edge -> edge.getData().getTarget())
-              .collect(Collectors.toList());
-      List<String> endingSteps = cytoscapeDAG.getEdges().stream().filter(edge -> edge.getData().getTarget().equals("UniqueEndKey")).map(edge -> edge.getData().getSource())
-              .collect(Collectors.toList());
-      List<String> knownStartingSteps = Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8");
-      List<String> knownEndingSteps = Arrays.asList("46", "45", "36", "35", "33", "32", "30", "29", "27", "26", "19", "18", "16", "15", "13", "12", "10", "9");
-      Collections.sort(knownStartingSteps);
-      Collections.sort(knownEndingSteps);
-      Collections.sort(startingSteps);
-      Collections.sort(endingSteps);
-      Assert.assertEquals(knownStartingSteps, startingSteps);
-      Assert.assertEquals(knownEndingSteps, endingSteps);
-    }
+  // Test with steps that don't have labels
+  @Test
+  public void testGetElements() throws Exception {
+    Gson gson = new Gson();
+    File testFile = new File("src/test/resources/transcriptomics-denovo-workflow.ga");
+    Map<String, Object> elements = Cytoscape.getElements(testFile.getAbsolutePath());
+    String json = gson.toJson(elements);
+    CytoscapeDAG cytoscapeDAG = gson.fromJson(json, CytoscapeDAG.class);
+    Set<String> collect =
+        cytoscapeDAG.getNodes().stream()
+            .map(node -> node.getData().getId())
+            .collect(Collectors.toSet());
+    Assert.assertEquals("Ids are distinct", collect.size(), cytoscapeDAG.getNodes().size());
+    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueBeginKey")));
+    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueEndKey")));
+    cytoscapeDAG.getEdges().stream()
+        .map(CytoscapeDAG.Edge::getData)
+        .forEach(
+            data ->
+                Assert.assertNotEquals(
+                    "Source and target should be different", data.getSource(), data.getTarget()));
+    Assert.assertFalse(elements.isEmpty());
+    List<String> startingSteps =
+        cytoscapeDAG.getEdges().stream()
+            .filter(edge -> edge.getData().getSource().equals("UniqueBeginKey"))
+            .map(edge -> edge.getData().getTarget())
+            .collect(Collectors.toList());
+    List<String> endingSteps =
+        cytoscapeDAG.getEdges().stream()
+            .filter(edge -> edge.getData().getTarget().equals("UniqueEndKey"))
+            .map(edge -> edge.getData().getSource())
+            .collect(Collectors.toList());
+    List<String> knownStartingSteps = Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8");
+    List<String> knownEndingSteps =
+        Arrays.asList(
+            "46", "45", "36", "35", "33", "32", "30", "29", "27", "26", "19", "18", "16", "15",
+            "13", "12", "10", "9");
+    Collections.sort(knownStartingSteps);
+    Collections.sort(knownEndingSteps);
+    Collections.sort(startingSteps);
+    Collections.sort(endingSteps);
+    Assert.assertEquals(knownStartingSteps, startingSteps);
+    Assert.assertEquals(knownEndingSteps, endingSteps);
+  }
+
+  /**
+   * Test with steps that have labels
+   * @throws Exception
+   */
+  @Test
+  public void testGetElements2() throws Exception {
+    Gson gson = new Gson();
+    File testFile = new File("src/test/resources/anotherFile.ga");
+    Map<String, Object> elements = Cytoscape.getElements(testFile.getAbsolutePath());
+    String json = gson.toJson(elements);
+    CytoscapeDAG cytoscapeDAG = gson.fromJson(json, CytoscapeDAG.class);
+    Set<String> collect =
+        cytoscapeDAG.getNodes().stream()
+            .map(node -> node.getData().getId())
+            .collect(Collectors.toSet());
+    Assert.assertEquals("Ids are distinct", collect.size(), cytoscapeDAG.getNodes().size());
+    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueBeginKey")));
+    Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueEndKey")));
+    cytoscapeDAG.getEdges().stream()
+        .map(CytoscapeDAG.Edge::getData)
+        .forEach(
+            data ->
+                Assert.assertNotEquals(
+                    "Source and target should be different", data.getSource(), data.getTarget()));
+    Assert.assertFalse(elements.isEmpty());
+    List<String> startingSteps =
+        cytoscapeDAG.getEdges().stream()
+            .filter(edge -> edge.getData().getSource().equals("UniqueBeginKey"))
+            .map(edge -> edge.getData().getTarget())
+            .collect(Collectors.toList());
+    List<String> endingSteps =
+        cytoscapeDAG.getEdges().stream()
+            .filter(edge -> edge.getData().getTarget().equals("UniqueEndKey"))
+            .map(edge -> edge.getData().getSource())
+            .collect(Collectors.toList());
+    List<String> knownStartingSteps = Collections.singletonList("0");
+    List<String> knownEndingSteps = Collections.singletonList("1");
+    Collections.sort(knownStartingSteps);
+    Collections.sort(knownEndingSteps);
+    Collections.sort(startingSteps);
+    Collections.sort(endingSteps);
+    Assert.assertEquals(knownStartingSteps, startingSteps);
+    Assert.assertEquals(knownEndingSteps, endingSteps);
+  }
 }

--- a/src/test/java/org/galaxyproject/gxformat2/CytoscapeTest.java
+++ b/src/test/java/org/galaxyproject/gxformat2/CytoscapeTest.java
@@ -1,0 +1,43 @@
+package org.galaxyproject.gxformat2;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CytoscapeTest {
+    @Test
+    public void testGetElements() throws Exception {
+        Gson gson = new Gson();
+        File testFile = new File("src/test/resources/transcriptomics-denovo-workflow.ga");
+        Map<String, Object> elements = Cytoscape.getElements(testFile.getAbsolutePath());
+        String json = gson.toJson(elements);
+        CytoscapeDAG cytoscapeDAG = gson.fromJson(json, CytoscapeDAG.class);
+        Set<String> collect = cytoscapeDAG.getNodes().stream().map(node -> node.getData().getId()).collect(Collectors.toSet());
+        Assert.assertEquals("Ids are distinct", collect.size(), cytoscapeDAG.getNodes().size());
+        Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueBeginKey")));
+        Assert.assertTrue(collect.stream().anyMatch(thing -> thing.equals("UniqueEndKey")));
+        cytoscapeDAG.getEdges().stream().map(CytoscapeDAG.Edge::getData)
+                .forEach(data -> Assert.assertNotEquals("Source and target should be different", data.getSource(), data.getTarget()));
+        Assert.assertFalse(elements.isEmpty());
+      List<String> startingSteps = cytoscapeDAG.getEdges().stream().filter(edge -> edge.getData().getSource().equals("UniqueBeginKey")).map(edge -> edge.getData().getTarget())
+              .collect(Collectors.toList());
+      List<String> endingSteps = cytoscapeDAG.getEdges().stream().filter(edge -> edge.getData().getTarget().equals("UniqueEndKey")).map(edge -> edge.getData().getSource())
+              .collect(Collectors.toList());
+      List<String> knownStartingSteps = Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "8");
+      List<String> knownEndingSteps = Arrays.asList("46", "45", "36", "35", "33", "32", "30", "29", "27", "26", "19", "18", "16", "15", "13", "12", "10", "9");
+      Collections.sort(knownStartingSteps);
+      Collections.sort(knownEndingSteps);
+      Collections.sort(startingSteps);
+      Collections.sort(endingSteps);
+      Assert.assertEquals(knownStartingSteps, startingSteps);
+      Assert.assertEquals(knownEndingSteps, endingSteps);
+    }
+}

--- a/src/test/resources/anotherFile.ga
+++ b/src/test/resources/anotherFile.ga
@@ -1,0 +1,79 @@
+{
+  "a_galaxy_workflow": "true",
+  "tags": [],
+  "format-version": "0.1",
+  "uuid": "120bee9d-4b50-46e5-a0f4-1cf13c78f243",
+  "steps": {
+    "0": {
+      "inputs": [
+        {
+          "description": "",
+          "name": "input1"
+        }
+      ],
+      "errors": null,
+      "name": "Input dataset",
+      "tool_id": null,
+      "outputs": [],
+      "tool_version": null,
+      "workflow_outputs": [],
+      "label": "input1",
+      "input_connections": {},
+      "id": 0,
+      "position": {
+        "top": 0,
+        "left": 0
+      },
+      "tool_state": "{\"name\": \"input1\"}",
+      "content_id": null,
+      "type": "data_input",
+      "annotation": "",
+      "uuid": "4eee58df-4eae-4792-8188-7e4b2a5ff816"
+    },
+    "1": {
+      "inputs": [
+        {
+          "description": "runtime parameter for tool Concatenate datasets (for test workflows)",
+          "name": "input1"
+        }
+      ],
+      "errors": null,
+      "name": "Concatenate datasets (for test workflows)",
+      "tool_id": "cat",
+      "outputs": [
+        {
+          "type": "input",
+          "name": "out_file1"
+        }
+      ],
+      "post_job_actions": {},
+      "tool_version": "1.0",
+      "workflow_outputs": [
+        {
+          "output_name": "out_file1",
+          "uuid": "0a88b8e1-589a-4b34-83c0-044e73730c29",
+          "label": "wf_output_1"
+        }
+      ],
+      "label": "first_cat",
+      "input_connections": {
+        "input1": {
+          "output_name": "output",
+          "id": 0
+        }
+      },
+      "id": 1,
+      "position": {
+        "top": 10,
+        "left": 10
+      },
+      "tool_state": "{\"__page__\": 0, \"__rerun_remap_job_id__\": null, \"input1\": \"{\\\"__class__\\\": \\\"RuntimeValue\\\"}\"}",
+      "content_id": "cat",
+      "type": "tool",
+      "annotation": "",
+      "uuid": "4ba0ea44-4eeb-4d66-b761-50f6608b551b"
+    }
+  },
+  "annotation": "",
+  "name": "Test Workflow"
+}

--- a/src/test/resources/transcriptomics-denovo-workflow.ga
+++ b/src/test/resources/transcriptomics-denovo-workflow.ga
@@ -1,0 +1,2234 @@
+{
+  "a_galaxy_workflow": "true",
+  "annotation": "De novo transcriptome reconstruction with RNA-Seq",
+  "format-version": "0.1",
+  "name": "Transcriptomics Denovo Workflow",
+  "steps": {
+    "0": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 0,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep1_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 10
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep1_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "cbc6590c-d6de-4abf-b53f-6c83b4ab4120",
+      "workflow_outputs": []
+    },
+    "1": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 1,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep1_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 130
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep1_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c2ba4aba-060a-40ba-88d6-e6fef8a1f2eb",
+      "workflow_outputs": []
+    },
+    "10": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 10,
+      "input_connections": {
+        "input_file": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "a4db4907-e8e9-4534-a37c-7c1d6c34de20",
+      "workflow_outputs": []
+    },
+    "11": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 11,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 0,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 1,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "d7a54fe5-9cd2-4209-9a02-b7d2d636b337",
+      "workflow_outputs": []
+    },
+    "12": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 12,
+      "input_connections": {
+        "input_file": {
+          "id": 2,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "c96f55e9-c898-4e79-abe2-0795b54d3a05",
+      "workflow_outputs": []
+    },
+    "13": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 13,
+      "input_connections": {
+        "input_file": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 490
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "d30af66b-0ab0-4bb9-8009-ce96a6c16993",
+      "workflow_outputs": []
+    },
+    "14": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 14,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 2,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 3,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 610
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "3d3cfa70-c027-40aa-b01c-52c36035fe92",
+      "workflow_outputs": []
+    },
+    "15": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 15,
+      "input_connections": {
+        "input_file": {
+          "id": 4,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 730
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "a6295400-a0ee-4790-9294-44e39e5df96c",
+      "workflow_outputs": []
+    },
+    "16": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 16,
+      "input_connections": {
+        "input_file": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 850
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "d7866331-a1c1-4c4b-8f6b-f7feb78fa78c",
+      "workflow_outputs": []
+    },
+    "17": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 17,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 4,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 5,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 970
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "c7ff55a4-e3df-4fde-93a3-ab0e175d5d6e",
+      "workflow_outputs": []
+    },
+    "18": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 18,
+      "input_connections": {
+        "input_file": {
+          "id": 6,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 1090
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "e56ae1f1-b6ee-4f0a-873b-fae2c345c216",
+      "workflow_outputs": []
+    },
+    "19": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 19,
+      "input_connections": {
+        "input_file": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 1210
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "d1068d72-f84b-431c-9137-38eb42606147",
+      "workflow_outputs": []
+    },
+    "2": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 2,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep2_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 250
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep2_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "c24cf053-248c-4922-874e-240f187853ca",
+      "workflow_outputs": []
+    },
+    "20": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "errors": null,
+      "id": 20,
+      "input_connections": {
+        "readtype|fastq_r1_in": {
+          "id": 6,
+          "output_name": "output"
+        },
+        "readtype|fastq_r2_in": {
+          "id": 7,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Trimmomatic",
+      "outputs": [
+        {
+          "name": "fastq_out_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_paired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r1_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out_r2_unpaired",
+          "type": "input"
+        },
+        {
+          "name": "fastq_out",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 1330
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/pjbriggs/trimmomatic/trimmomatic/0.36.5",
+      "tool_shed_repository": {
+        "changeset_revision": "dfa082f84068",
+        "name": "trimmomatic",
+        "owner": "pjbriggs",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"operations\": \"[{\\\"__index__\\\": 0, \\\"operation\\\": {\\\"window_size\\\": \\\"4\\\", \\\"name\\\": \\\"SLIDINGWINDOW\\\", \\\"__current_case__\\\": 0, \\\"required_quality\\\": \\\"20\\\"}}]\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"readtype\": \"{\\\"single_or_paired\\\": \\\"pair_of_files\\\", \\\"fastq_r1_in\\\": null, \\\"__current_case__\\\": 1, \\\"fastq_r2_in\\\": null}\", \"illuminaclip\": \"{\\\"do_illuminaclip\\\": \\\"false\\\", \\\"__current_case__\\\": 1}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.36.5",
+      "type": "tool",
+      "uuid": "81433b00-0996-44b0-ae73-db880a8c68c0",
+      "workflow_outputs": []
+    },
+    "21": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 21,
+      "input_connections": {
+        "library|input_1": {
+          "id": 11,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 11,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "817cc498-44f1-4813-92f0-3b88fed3451f",
+      "workflow_outputs": []
+    },
+    "22": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 22,
+      "input_connections": {
+        "library|input_1": {
+          "id": 14,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 14,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "1e92db79-135e-4a5e-9d3f-ea0d7f5045da",
+      "workflow_outputs": []
+    },
+    "23": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 23,
+      "input_connections": {
+        "library|input_1": {
+          "id": 17,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 17,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "c488973c-6fe1-4f11-9268-1f108e3e1aae",
+      "workflow_outputs": []
+    },
+    "24": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "errors": null,
+      "id": 24,
+      "input_connections": {
+        "library|input_1": {
+          "id": 20,
+          "output_name": "fastq_out_r1_paired"
+        },
+        "library|input_2": {
+          "id": 20,
+          "output_name": "fastq_out_r2_paired"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "HISAT2",
+      "outputs": [
+        {
+          "name": "output_alignments",
+          "type": "bam"
+        },
+        {
+          "name": "output_unaligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_l",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_unaligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "output_aligned_reads_r",
+          "type": "fastqsanger"
+        },
+        {
+          "name": "summary_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 450,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.1.0",
+      "tool_shed_repository": {
+        "changeset_revision": "6ab42baa56e9",
+        "name": "hisat2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"alignment_options\\\": {\\\"__current_case__\\\": 0, \\\"alignment_options_selector\\\": \\\"defaults\\\"}, \\\"output_options\\\": {\\\"output_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"other_options\\\": {\\\"other_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"scoring_options\\\": {\\\"scoring_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"spliced_options\\\": {\\\"coefficient\\\": \\\"0.0\\\", \\\"canonical_penalty\\\": \\\"0\\\", \\\"no_spliced_alignment_options\\\": {\\\"no_spliced_alignment\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"nc_function_type\\\": \\\"C\\\", \\\"constant_term\\\": \\\"0.0\\\", \\\"nc_coefficient\\\": \\\"1.0\\\", \\\"noncanonical_penalty\\\": \\\"3\\\", \\\"known_splice_gtf\\\": null, \\\"nc_constant_term\\\": \\\"-8.0\\\", \\\"min_intron\\\": \\\"20\\\", \\\"function_type\\\": \\\"C\\\", \\\"__current_case__\\\": 1, \\\"notmplen\\\": \\\"false\\\", \\\"tma\\\": \\\"--dta\\\", \\\"max_intron\\\": \\\"500000\\\", \\\"spliced_options_selector\\\": \\\"advanced\\\"}, \\\"reporting_options\\\": {\\\"reporting_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}, \\\"input_options\\\": {\\\"input_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"__page__\": null, \"sum\": \"{\\\"new_summary\\\": \\\"false\\\", \\\"summary_file\\\": \\\"false\\\"}\", \"library\": \"{\\\"rna_strandness\\\": \\\"FR\\\", \\\"input_2\\\": null, \\\"__current_case__\\\": 1, \\\"input_1\\\": null, \\\"type\\\": \\\"paired\\\", \\\"paired_options\\\": {\\\"paired_options_selector\\\": \\\"defaults\\\", \\\"__current_case__\\\": 0}}\", \"reference_genome\": \"{\\\"source\\\": \\\"indexed\\\", \\\"__current_case__\\\": 0, \\\"index\\\": \\\"mm10\\\"}\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "2.1.0",
+      "type": "tool",
+      "uuid": "614c1c41-fcd0-447e-8514-c0876641809d",
+      "workflow_outputs": []
+    },
+    "25": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 25,
+      "input_connections": {
+        "input_bam": {
+          "id": 21,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "5fbbf39b-c5da-435e-a7cf-4d0d3ed9e05e",
+      "workflow_outputs": []
+    },
+    "26": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 26,
+      "input_connections": {
+        "bamInput": {
+          "id": 21,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 490
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "d61115e2-0a95-4b80-93bb-a14183d0e219",
+      "workflow_outputs": []
+    },
+    "27": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 27,
+      "input_connections": {
+        "bamInput": {
+          "id": 21,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 970
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "72051e92-7fc3-447f-b289-e9d7e7043397",
+      "workflow_outputs": []
+    },
+    "28": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 28,
+      "input_connections": {
+        "input_bam": {
+          "id": 22,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "c96d2ba9-5fb2-444f-afa1-8311a54460c0",
+      "workflow_outputs": []
+    },
+    "29": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 29,
+      "input_connections": {
+        "bamInput": {
+          "id": 22,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 610
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "e2b0c494-a05a-4fd7-9d32-97f466fe3bcf",
+      "workflow_outputs": []
+    },
+    "3": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 3,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "G1E_rep2_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 370
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"G1E_rep2_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "4d89fd77-a8ae-41c8-8dfe-e9446fdeaddb",
+      "workflow_outputs": []
+    },
+    "30": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 30,
+      "input_connections": {
+        "bamInput": {
+          "id": 22,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 1090
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "b4c95c39-273b-4138-bbad-8e46a3adfaae",
+      "workflow_outputs": []
+    },
+    "31": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 31,
+      "input_connections": {
+        "input_bam": {
+          "id": 23,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "4c15f586-8fe3-4dca-94fe-2ca0205ec76e",
+      "workflow_outputs": []
+    },
+    "32": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 32,
+      "input_connections": {
+        "bamInput": {
+          "id": 23,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 730
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "9a7a8ac0-a980-4b19-91d8-a775af979957",
+      "workflow_outputs": []
+    },
+    "33": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 33,
+      "input_connections": {
+        "bamInput": {
+          "id": 23,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 1210
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "cac5762b-01b2-492e-ab4a-ed6ca63b65de",
+      "workflow_outputs": []
+    },
+    "34": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "errors": null,
+      "id": 34,
+      "input_connections": {
+        "input_bam": {
+          "id": 24,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie",
+      "outputs": [
+        {
+          "name": "output_gtf",
+          "type": "gtf"
+        },
+        {
+          "name": "gene_abundance_estimation",
+          "type": "gtf"
+        },
+        {
+          "name": "coverage",
+          "type": "gtf"
+        },
+        {
+          "name": "exon_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_expression",
+          "type": "tabular"
+        },
+        {
+          "name": "exon_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "intron_transcript_mapping",
+          "type": "tabular"
+        },
+        {
+          "name": "gene_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "transcript_counts",
+          "type": "tabular"
+        },
+        {
+          "name": "legend",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie/1.3.3.2",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"adv\": \"{\\\"min_bundle_cov\\\": \\\"2\\\", \\\"min_tlen\\\": \\\"200\\\", \\\"bdist\\\": \\\"50\\\", \\\"multi_mapping\\\": \\\"false\\\", \\\"abundance_estimation\\\": \\\"false\\\", \\\"fraction\\\": \\\"0.15\\\", \\\"disable_trimming\\\": \\\"false\\\", \\\"omit_sequences\\\": \\\"\\\", \\\"name_prefix\\\": \\\"\\\", \\\"min_anchor_len\\\": \\\"10\\\", \\\"bundle_fraction\\\": \\\"0.95\\\", \\\"min_anchor_cov\\\": \\\"1\\\"}\", \"__page__\": null, \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"rna_strandness\": \"\\\"--fr\\\"\", \"input_bam\": \"null\", \"guide\": \"{\\\"use_guide\\\": \\\"no\\\", \\\"__current_case__\\\": 0}\"}",
+      "tool_version": "1.3.3.2",
+      "type": "tool",
+      "uuid": "1538c29a-305e-454e-801c-e4501fb326b1",
+      "workflow_outputs": []
+    },
+    "35": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 35,
+      "input_connections": {
+        "bamInput": {
+          "id": 24,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 850
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"forward\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "63c35755-3978-4c47-9063-bd06737ccafc",
+      "workflow_outputs": []
+    },
+    "36": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "errors": null,
+      "id": 36,
+      "input_connections": {
+        "bamInput": {
+          "id": 24,
+          "output_name": "output_alignments"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "bamCoverage",
+      "outputs": [
+        {
+          "name": "outFileName",
+          "type": "bigwig"
+        }
+      ],
+      "position": {
+        "left": 670,
+        "top": 1330
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.0.2.0",
+      "tool_shed_repository": {
+        "changeset_revision": "3033c3fba046",
+        "name": "deeptools_bam_coverage",
+        "owner": "bgruening",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"outFileFormat\": \"\\\"bigwig\\\"\", \"region\": \"\\\"\\\"\", \"bamInput\": \"null\", \"binSize\": \"\\\"1\\\"\", \"scaling\": \"{\\\"effectiveGenomeSize\\\": {\\\"effectiveGenomeSize_opt\\\": \\\"2304947926\\\", \\\"__current_case__\\\": 6}, \\\"type\\\": \\\"1x\\\", \\\"__current_case__\\\": 4}\", \"advancedOpt\": \"{\\\"ignoreDuplicates\\\": \\\"false\\\", \\\"centerReads\\\": \\\"false\\\", \\\"ignoreForNormalization\\\": \\\"\\\", \\\"minFragmentLength\\\": \\\"0\\\", \\\"minMappingQuality\\\": \\\"1\\\", \\\"MNase\\\": \\\"false\\\", \\\"samFlagInclude\\\": \\\"\\\", \\\"filterRNAstrand\\\": \\\"reverse\\\", \\\"Offset\\\": \\\"\\\", \\\"smoothLength\\\": \\\"\\\", \\\"showAdvancedOpt\\\": \\\"yes\\\", \\\"__current_case__\\\": 1, \\\"samFlagExclude\\\": \\\"\\\", \\\"doExtendCustom\\\": {\\\"__current_case__\\\": 0, \\\"doExtend\\\": \\\"no\\\"}, \\\"skipNAs\\\": \\\"false\\\", \\\"scaleFactor\\\": \\\"1.0\\\", \\\"blackListFileName\\\": null, \\\"maxFragmentLength\\\": \\\"0\\\"}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"__rerun_remap_job_id__\": null}",
+      "tool_version": "3.0.2.0",
+      "type": "tool",
+      "uuid": "dbe2b8a3-bc6a-461c-8ca3-06b3966edbdd",
+      "workflow_outputs": []
+    },
+    "37": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie_merge/1.3.3",
+      "errors": null,
+      "id": 37,
+      "input_connections": {
+        "guide_gff": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "input_gtf": [
+          {
+            "id": 31,
+            "output_name": "output_gtf"
+          },
+          {
+            "id": 34,
+            "output_name": "output_gtf"
+          },
+          {
+            "id": 25,
+            "output_name": "output_gtf"
+          },
+          {
+            "id": 28,
+            "output_name": "output_gtf"
+          }
+        ]
+      },
+      "inputs": [],
+      "label": null,
+      "name": "StringTie merge",
+      "outputs": [
+        {
+          "name": "out_gtf",
+          "type": "gtf"
+        }
+      ],
+      "position": {
+        "left": 890,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/stringtie/stringtie_merge/1.3.3",
+      "tool_shed_repository": {
+        "changeset_revision": "eafd5dc95228",
+        "name": "stringtie",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"keep_introns\": \"\\\"false\\\"\", \"min_fpkm\": \"\\\"1.0\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"min_len\": \"\\\"50\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"guide_gff\": \"null\", \"min_cov\": \"\\\"0\\\"\", \"min_iso\": \"\\\"0.01\\\"\", \"min_tpm\": \"\\\"1.0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"input_gtf\": \"null\", \"gap_len\": \"\\\"250\\\"\"}",
+      "tool_version": "1.3.3",
+      "type": "tool",
+      "uuid": "47307af1-9fd1-4936-a01e-ca9d660173e7",
+      "workflow_outputs": []
+    },
+    "38": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8",
+      "errors": null,
+      "id": 38,
+      "input_connections": {
+        "annotation|reference_annotation": {
+          "id": 8,
+          "output_name": "output"
+        },
+        "inputs": {
+          "id": 37,
+          "output_name": "out_gtf"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "GffCompare",
+      "outputs": [
+        {
+          "name": "transcripts_stats",
+          "type": "txt"
+        },
+        {
+          "name": "transcripts_loci",
+          "type": "tabular"
+        },
+        {
+          "name": "transcripts_tracking",
+          "type": "tabular"
+        },
+        {
+          "name": "transcripts_combined",
+          "type": "gtf"
+        },
+        {
+          "name": "transcripts_annotated",
+          "type": "gtf"
+        }
+      ],
+      "position": {
+        "left": 1110,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/gffcompare/gffcompare/0.9.8",
+      "tool_shed_repository": {
+        "changeset_revision": "3c97c841a443",
+        "name": "gffcompare",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"seq_data\": \"{\\\"use_seq_data\\\": \\\"Yes\\\", \\\"seq_source\\\": {\\\"index_source\\\": \\\"cached\\\", \\\"index\\\": \\\"mm10\\\", \\\"__current_case__\\\": 0}, \\\"__current_case__\\\": 1}\", \"inputs\": \"null\", \"max_dist_group\": \"\\\"100\\\"\", \"__page__\": null, \"max_dist_exon\": \"\\\"100\\\"\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"discard_single_exon\": \"\\\"\\\"\", \"discard_intron_redundant_transfrags\": \"\\\"false\\\"\", \"annotation\": \"{\\\"reference_annotation\\\": null, \\\"use_ref_annotation\\\": \\\"Yes\\\", \\\"ignore_nonoverlapping_reference\\\": \\\"false\\\", \\\"__current_case__\\\": 0, \\\"ignore_nonoverlapping_transfrags\\\": \\\"false\\\"}\"}",
+      "tool_version": "0.9.8",
+      "type": "tool",
+      "uuid": "6292c087-6c93-435e-ab1f-348ce4bff2bb",
+      "workflow_outputs": []
+    },
+    "39": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 39,
+      "input_connections": {
+        "alignment": {
+          "id": 21,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "fc054e7c-a603-4aa6-b3cf-d2e1cd4d7be9",
+      "workflow_outputs": []
+    },
+    "4": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 4,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep1_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 490
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep1_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "41e16899-910c-4750-84cf-4bddc17437c2",
+      "workflow_outputs": []
+    },
+    "40": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 40,
+      "input_connections": {
+        "alignment": {
+          "id": 22,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "a29ab182-8103-425e-86e8-d71a08277f7c",
+      "workflow_outputs": []
+    },
+    "41": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 41,
+      "input_connections": {
+        "alignment": {
+          "id": 23,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 250
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "8b73ac2b-9e21-4cd3-bff2-ce0215d3a213",
+      "workflow_outputs": []
+    },
+    "42": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "errors": null,
+      "id": 42,
+      "input_connections": {
+        "alignment": {
+          "id": 24,
+          "output_name": "output_alignments"
+        },
+        "anno|reference_gene_sets": {
+          "id": 38,
+          "output_name": "transcripts_annotated"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "featureCounts",
+      "outputs": [
+        {
+          "name": "output_medium",
+          "type": "tabular"
+        },
+        {
+          "name": "output_short",
+          "type": "tabular"
+        },
+        {
+          "name": "output_full",
+          "type": "tabular"
+        },
+        {
+          "name": "output_summary",
+          "type": "tabular"
+        },
+        {
+          "name": "output_feature_lengths",
+          "type": "tabular"
+        },
+        {
+          "name": "output_jcounts",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1330,
+        "top": 370
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/1.6.0.6",
+      "tool_shed_repository": {
+        "changeset_revision": "92808b865dfb",
+        "name": "featurecounts",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"pe_parameters\": \"{\\\"only_both_ends\\\": \\\"false\\\", \\\"exclude_chimerics\\\": \\\"true\\\", \\\"fragment_counting_enabled\\\": {\\\"fragment_counting\\\": \\\"\\\", \\\"__current_case__\\\": 1}}\", \"format\": \"\\\"tabdel_short\\\"\", \"__page__\": null, \"__rerun_remap_job_id__\": null, \"strand_specificity\": \"\\\"1\\\"\", \"include_feature_length_file\": \"\\\"false\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"anno\": \"{\\\"anno_select\\\": \\\"history\\\", \\\"reference_gene_sets\\\": null, \\\"__current_case__\\\": 2}\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"extended_parameters\": \"{\\\"gff_feature_attribute\\\": \\\"transcript_id\\\", \\\"exon_exon_junction_read_counting_enabled\\\": {\\\"__current_case__\\\": 1, \\\"count_exon_exon_junction_reads\\\": \\\"false\\\"}, \\\"read_extension_3p\\\": \\\"0\\\", \\\"frac_overlap_feature\\\": \\\"0\\\", \\\"min_overlap\\\": \\\"1\\\", \\\"read_extension_5p\\\": \\\"0\\\", \\\"contribute_to_multiple_features\\\": \\\"false\\\", \\\"frac_overlap\\\": \\\"0\\\", \\\"primary\\\": \\\"false\\\", \\\"count_split_alignments_only\\\": \\\"false\\\", \\\"by_read_group\\\": \\\"false\\\", \\\"ignore_dup\\\": \\\"false\\\", \\\"mapping_quality\\\": \\\"12\\\", \\\"summarization_level\\\": \\\"false\\\", \\\"largest_overlap\\\": \\\"false\\\", \\\"read_reduction\\\": \\\"\\\", \\\"multimapping_enabled\\\": {\\\"multimapping_counts\\\": \\\"\\\", \\\"__current_case__\\\": 1}, \\\"long_reads\\\": \\\"false\\\", \\\"gff_feature_type\\\": \\\"exon\\\"}\", \"alignment\": \"null\"}",
+      "tool_version": "1.6.0.6",
+      "type": "tool",
+      "uuid": "02a66170-4c0c-4c1e-8073-ec626190390e",
+      "workflow_outputs": []
+    },
+    "43": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.2",
+      "errors": null,
+      "id": 43,
+      "input_connections": {
+        "rep_factorName_0|rep_factorLevel_0|countsFile": [
+          {
+            "id": 39,
+            "output_name": "output_short"
+          },
+          {
+            "id": 40,
+            "output_name": "output_short"
+          }
+        ],
+        "rep_factorName_0|rep_factorLevel_1|countsFile": [
+          {
+            "id": 41,
+            "output_name": "output_short"
+          },
+          {
+            "id": 42,
+            "output_name": "output_short"
+          }
+        ]
+      },
+      "inputs": [],
+      "label": null,
+      "name": "DESeq2",
+      "outputs": [
+        {
+          "name": "split_output",
+          "type": "input"
+        },
+        {
+          "name": "deseq_out",
+          "type": "tabular"
+        },
+        {
+          "name": "plots",
+          "type": "pdf"
+        },
+        {
+          "name": "counts_out",
+          "type": "tabular"
+        }
+      ],
+      "position": {
+        "left": 1550,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40.2",
+      "tool_shed_repository": {
+        "changeset_revision": "9a616afdbda5",
+        "name": "deseq2",
+        "owner": "iuc",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"fit_type\": \"\\\"1\\\"\", \"__page__\": null, \"tximport\": \"{\\\"tximport_selector\\\": \\\"count\\\", \\\"__current_case__\\\": 1}\", \"outlier_replace_off\": \"\\\"false\\\"\", \"__rerun_remap_job_id__\": null, \"auto_mean_filter_off\": \"\\\"false\\\"\", \"header\": \"\\\"true\\\"\", \"rep_factorName\": \"[{\\\"__index__\\\": 0, \\\"factorName\\\": \\\"FactorName\\\", \\\"rep_factorLevel\\\": [{\\\"__index__\\\": 0, \\\"factorLevel\\\": \\\"GIE\\\", \\\"countsFile\\\": null}, {\\\"__index__\\\": 1, \\\"factorLevel\\\": \\\"Mega\\\", \\\"countsFile\\\": null}]}]\", \"normCounts\": \"\\\"true\\\"\", \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"many_contrasts\": \"\\\"false\\\"\", \"pdf\": \"\\\"true\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\", \"outlier_filter_off\": \"\\\"false\\\"\"}",
+      "tool_version": "2.11.40.2",
+      "type": "tool",
+      "uuid": "73d67b36-4316-446b-85f6-5b1e2b64f684",
+      "workflow_outputs": []
+    },
+    "44": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 44,
+      "input_connections": {
+        "input": {
+          "id": 43,
+          "output_name": "deseq_out"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1770,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c7<0.05\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "3581c4be-1732-47fc-ad14-73f5e3a42b23",
+      "workflow_outputs": []
+    },
+    "45": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 45,
+      "input_connections": {
+        "input": {
+          "id": 44,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1990,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3>0\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "c9d279df-d6bb-4b48-a743-250e9fb30548",
+      "workflow_outputs": []
+    },
+    "46": {
+      "annotation": "",
+      "content_id": "Filter1",
+      "errors": null,
+      "id": 46,
+      "input_connections": {
+        "input": {
+          "id": 44,
+          "output_name": "out_file1"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "Filter",
+      "outputs": [
+        {
+          "name": "out_file1",
+          "type": "input"
+        }
+      ],
+      "position": {
+        "left": 1990,
+        "top": 130
+      },
+      "post_job_actions": {},
+      "tool_id": "Filter1",
+      "tool_state": "{\"__page__\": null, \"__rerun_remap_job_id__\": null, \"cond\": \"\\\"c3<0\\\"\", \"input\": \"null\", \"header_lines\": \"\\\"0\\\"\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/mm10.len\\\"\"}",
+      "tool_version": "1.1.0",
+      "type": "tool",
+      "uuid": "aa0f881b-5524-4a0c-9cc5-c8fdfe2e3b89",
+      "workflow_outputs": []
+    },
+    "5": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 5,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep1_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 610
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep1_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "e7b2ddb1-99fc-4898-9c10-e5ac8fa9fd3a",
+      "workflow_outputs": []
+    },
+    "6": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 6,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep2_forward_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 730
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep2_forward_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "8eff105a-d216-4399-bac1-a67d3f09514f",
+      "workflow_outputs": []
+    },
+    "7": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 7,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "Megakaryocyte_rep2_reverse_read"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 850
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"Megakaryocyte_rep2_reverse_read\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "f22827e1-68d3-4ae0-9d4a-67bca6a8b288",
+      "workflow_outputs": []
+    },
+    "8": {
+      "annotation": "",
+      "content_id": null,
+      "errors": null,
+      "id": 8,
+      "input_connections": {},
+      "inputs": [
+        {
+          "description": "",
+          "name": "RefSeq_reference_GTF"
+        }
+      ],
+      "label": null,
+      "name": "Input dataset",
+      "outputs": [],
+      "position": {
+        "left": 10,
+        "top": 970
+      },
+      "tool_id": null,
+      "tool_state": "{\"name\": \"RefSeq_reference_GTF\"}",
+      "tool_version": null,
+      "type": "data_input",
+      "uuid": "758d9ac9-4e4a-45fa-a5ad-2fb4f5f7f87d",
+      "workflow_outputs": []
+    },
+    "9": {
+      "annotation": "",
+      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "errors": null,
+      "id": 9,
+      "input_connections": {
+        "input_file": {
+          "id": 0,
+          "output_name": "output"
+        }
+      },
+      "inputs": [],
+      "label": null,
+      "name": "FastQC",
+      "outputs": [
+        {
+          "name": "html_file",
+          "type": "html"
+        },
+        {
+          "name": "text_file",
+          "type": "txt"
+        }
+      ],
+      "position": {
+        "left": 230,
+        "top": 10
+      },
+      "post_job_actions": {},
+      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72",
+      "tool_shed_repository": {
+        "changeset_revision": "c15237684a01",
+        "name": "fastqc",
+        "owner": "devteam",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "tool_state": "{\"__page__\": null, \"limits\": \"null\", \"input_file\": \"null\", \"__rerun_remap_job_id__\": null, \"__workflow_invocation_uuid__\": \"\\\"fde8952eb77711e8a468005056ba55fb\\\"\", \"contaminants\": \"null\", \"chromInfo\": \"\\\"/cvmfs/data.galaxyproject.org/managed/len/ucsc/?.len\\\"\"}",
+      "tool_version": "0.72",
+      "type": "tool",
+      "uuid": "32c35846-2972-4d71-8af6-03350acd490a",
+      "workflow_outputs": []
+    }
+  },
+  "tags": [
+    "transcriptomics"
+  ],
+  "uuid": "dc8abeee-46fa-4965-9a58-396b3ac0c310"
+}


### PR DESCRIPTION
Not entirely sure if this is correct, but the DAG is actually a DAG now.  Also, the type field in Dockstore.org is now populated.  

Added start and end nodes.

https://dev.dockstore.net/workflows/github.com/galaxyproject/training-material/transcriptomics-denovo:master?tab=dag now looks like:

![image](https://user-images.githubusercontent.com/24548904/75927004-85d99f00-5e39-11ea-8f8f-f4836dafd384.png)
