### PR TITLE
Jackson update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>dockstore-galaxy-interface</artifactId>
     <packaging>jar</packaging>
     <name>dockstore-galaxy-interface</name>
-    <version>0.0.4-SNAPSHOT</version>
+    <version>0.0.5</version>
 
     <properties>
         <github.url>scm:git:git@github.com:galaxyproject/dockstore-galaxy-interface.git</github.url>
@@ -32,7 +32,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>1.1.3</tag>
+        <tag>dockstore-galaxy-interface-0.0.5</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <plugin.id>${project.artifactId}</plugin.id>
         <plugin.class>org.galaxyproject.dockstore_galaxy_interface.language.GalaxyWorkflowPlugin</plugin.class>
         <plugin.version>${project.version}</plugin.version>
-        <jackson.version>2.10.1</jackson.version>
+        <jackson.version>2.11.3</jackson.version>
         <plugin.provider>jmchilton</plugin.provider>
         <plugin.dependencies />
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>dockstore-galaxy-interface</artifactId>
     <packaging>jar</packaging>
     <name>dockstore-galaxy-interface</name>
-    <version>0.0.5</version>
+    <version>0.0.6-SNAPSHOT</version>
 
     <properties>
         <github.url>scm:git:git@github.com:galaxyproject/dockstore-galaxy-interface.git</github.url>
@@ -32,7 +32,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>dockstore-galaxy-interface-0.0.5</tag>
+        <tag>1.1.3</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
Didn't actually need this (confused it with https://github.com/swagger-api/swagger-core/releases/tag/v1.6.2 needing a newer version of jackson) but I'll leave this in here to explain the extra release